### PR TITLE
Removing errant whitespace

### DIFF
--- a/2.x/rbl.conf
+++ b/2.x/rbl.conf
@@ -53,7 +53,7 @@ rbls {
         }
     }
     SH_EMAIL_DBL {
-       ignore_defaults = true;                                                                                                                                                     
+       ignore_defaults = true;
        replyto = true;
        emails_domainonly = true;
        rbl = "your_DQS_key.dbl.dq.spamhaus.net"
@@ -74,7 +74,7 @@ rbls {
        }
     }
     SH_EMAIL_ZRD {
-       ignore_defaults = true;                                                                                                                                                     
+       ignore_defaults = true;
        replyto = true;
        emails_domainonly = true;
        rbl = "your_DQS_key.zrd.dq.spamhaus.net"
@@ -94,8 +94,8 @@ rbls {
       rbl = "your_DQS_key.dbl.dq.spamhaus.net";
    }
    "ZRD" {
-      rbl = "your_DQS_key.zrd.dq.spamhaus.net";                                                                                                                      
-      no_ip = true;                                                                                                                                                     
+      rbl = "your_DQS_key.zrd.dq.spamhaus.net";
+      no_ip = true;
       dkim = true;
       emails = true;
       emails_domainonly = true;


### PR DESCRIPTION
There's a lot of spaces at the end of a handful of lines. This trims them, thus restoring my sanity when editing in vim and seeing a "random" number of empty lines depending upon my terminal size.