### PR TITLE
Fix for Rspamd monitoring error on ZRD BL.

### DIFF
--- a/2.x/rbl.conf
+++ b/2.x/rbl.conf
@@ -98,6 +98,7 @@ rbls {
        ignore_defaults = true;
        replyto = true;
        emails_domainonly = true;
+       disable_monitoring = true;
        rbl = "your_DQS_key.zrd.dq.spamhaus.net"
        returncodes = {
          SH_EMAIL_ZRD_VERY_FRESH_DOMAIN = [


### PR DESCRIPTION
Fix for 2020-12-28 11:06:26 #14613(controller) <86a3cx>; monitored; rspamd_monitored_dns_cb: DNS reply returned 'no error' for key.zrd.dq.spamhaus.net while 'no records with this name' was expected when querying for '1.0.0.127.key.zrd.dq.spamhaus.net'(likely DNS spoofing or BL internal issues)