### PR TITLE
Updated rbl.conf for Rspamd 3.7.2

### DIFF
--- a/3.x/rbl.conf
+++ b/3.x/rbl.conf
@@ -13,7 +13,7 @@ rbls {
 #          SPAMHAUS_ZEN_CSS = "127.0.0.3";
 #          SPAMHAUS_ZEN_XBL = [ "127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7" ];
 #          SPAMHAUS_ZEN_PBL = [ "127.0.0.10", "127.0.0.11" ];
-	  SPAMHAUS_ZEN = [ "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7", "127.0.0.9", "127.0.0.10", "127.0.0.11" ];
+          SPAMHAUS_ZEN = [ "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6", "127.0.0.7", "127.0.0.9", "127.0.0.10", "127.0.0.11" ];
         }
     }
     spamhaus_authbl_received {
@@ -31,7 +31,7 @@ rbls {
         rbl = "your_DQS_key.dbl.dq.spamhaus.net";
         helo = true;
         rdns = true;
-	dkim = true;
+        dkim = true;
         disable_monitoring = true;
         returncodes {
             RBL_DBL_SPAM = "127.0.1.2";
@@ -46,10 +46,10 @@ rbls {
         }
     }
     spamhaus_dbl_fullurls {
-	ignore_defaults = true;
-	no_ip = true;
-	rbl = "your_DQS_key.dbl.dq.spamhaus.net";
-	selector = 'urls:get_host'
+        ignore_defaults = true;
+        no_ip = true;
+        rbl = "your_DQS_key.dbl.dq.spamhaus.net";
+        selector = 'urls:get_host'
         disable_monitoring = true;
         returncodes {
             DBLABUSED_SPAM_FULLURLS = "127.0.1.102";
@@ -63,15 +63,17 @@ rbls {
         rbl = "your_DQS_key.zrd.dq.spamhaus.net";
         helo = true;
         rdns = true;
-	dkim = true;
+        dkim = true;
         disable_monitoring = true;
+        returncodes_matcher = "luapattern";
         returncodes {
-            RBL_ZRD_VERY_FRESH_DOMAIN = "127.0.2.[2-4]+";
-            RBL_ZRD_FRESH_DOMAIN = ["127.0.2.[5-9]+","127.0.2.1[0-9]+","127.0.2.2[0-4]+"];
-            RBL_ZRD_DONT_QUERY_IPS = "127.0.2.255";
+            RBL_ZRD_VERY_FRESH_DOMAIN = "127%.0%.2%.[2-4]+";
+            RBL_ZRD_FRESH_DOMAIN = ["127%.0%.2%.[5-9]+","127%.0%.2%.1[0-9]+","127%.0%.2%.2[0-4]+"];
+            RBL_ZRD_DONT_QUERY_IPS = "127%.0%.2%.255";
         }
     }
     "SPAMHAUS_ZEN_URIBL" {
+      enabled = true;
       rbl = "your_DQS_key.zen.dq.spamhaus.net";
       resolve_ip = true;
       checks = ['urls'];
@@ -116,16 +118,17 @@ rbls {
        emails_domainonly = true;
        disable_monitoring = true;
        rbl = "your_DQS_key.zrd.dq.spamhaus.net"
+       returncodes_matcher = "luapattern";
        returncodes = {
          SH_EMAIL_ZRD_VERY_FRESH_DOMAIN = [
-           "127.0.2.[2-4]+"
+           "127%.0%.2%.[2-4]+"
          ];
          SH_EMAIL_ZRD_FRESH_DOMAIN = [
-           "127.0.2.[5-9]+",
-           "127.0.2.1[0-9]+",
-           "127.0.2.2[0-4]+"
+           "127%.0%.2%.[5-9]+",
+           "127%.0%.2%.1[0-9]+",
+           "127%.0%.2%.2[0-4]+"
          ];
-         SH_EMAIL_ZRD_DONT_QUERY_IPS = [ "127.0.2.255" ];
+         SH_EMAIL_ZRD_DONT_QUERY_IPS = [ "127%.0%.2%.255" ];
        }
    } 
    "DBL" {
@@ -146,7 +149,7 @@ rbls {
       }
    }
    spamhaus_sbl_url {
-	ignore_defaults = true
+        ignore_defaults = true
         rbl = "your_DQS_key.sbl.dq.spamhaus.net";
         checks = ['urls'];
         disable_monitoring = true;


### PR DESCRIPTION
With Rspamd version 3.7.2 the returncode matching for the RBL module was changed
(see https://rspamd.com/doc/modules/rbl.html#returncodes-matchers). Adjusted the configuration for spamhaus_zrd and SH_EMAIL_ZRD accordingly. Also enabled SPAMHAUS_ZEN_URIBL which is disabled in the Rspamd default configuration and fixed some indentation.