### PR TITLE
Fix memory leaks

### DIFF
--- a/3.x/rspamd.local.lua
+++ b/3.x/rspamd.local.lua
@@ -512,10 +512,6 @@ local function url_to_hash(url, urlspec)
     if ufragment ~= nil then
         upath = upath .. "#" .. ufragment
     end
-    -- decode %-escaped characters
-    upath = upath:gsub("%%(%x%x)", function (h)
-        return string.char("0x" .. h)
-    end)
     -- XXX working around memory issues in rspamd_regexp
     -- local hpart = urlspec.algre[alg]:search(upath)
     local cre = urlspec.algref[alg]

--- a/3.x/rspamd.local.lua
+++ b/3.x/rspamd.local.lua
@@ -610,7 +610,7 @@ local function reload_urlspec(_, _)
 end
 
 local function download_urlspec(cfg, ev_base)
-    local req_hdrs = { ['User-Agent']= 'rspamd-dqs 20240208' }
+    local req_hdrs = { ['User-Agent']= 'rspamd-dqs 20240403' }
     local _, stat = rspamd_util.stat(sh_urlspec_file)
     if stat ~= nil then
         req_hdrs['If-Modified-Since'] = rspamd_util.time_to_string(stat.mtime)

--- a/3.x/settings.conf
+++ b/3.x/settings.conf
@@ -1,4 +1,5 @@
 spamhaus {
   dqs = "your_DQS_key"
   max_urls = 100
+  max_cws = 100
 }


### PR DESCRIPTION
Work around rspamd_regexp bug by rewriting URL normalization regexes into lua patterns. Translation is not exact but good enough for current regexes in use by spamhaus.
Rewrite cryptowallet matching, no longer use async calls from regex conditions, but use a regular filter_words on text parts.